### PR TITLE
use CGLIB >= 3.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ spock_version           = 1.0-groovy-2.4
 mockito_version         = 2.0.8-beta
 junit_vesion            = 4.+
 
-cglib_version           = 3.1
+cglib_version           = 3.2.4
 objenesis_version       = 2.1
 
 yamlbeans_version       = 1.09

--- a/test1/src/test/groovy/test/AnnotationMetaTest.groovy
+++ b/test1/src/test/groovy/test/AnnotationMetaTest.groovy
@@ -8,7 +8,7 @@ class AnnotationMetaTest extends Specification {
     def mockTest = Mock(AnnotationMeta.Builder1)
 
     when:
-    mockTest.getInstance()
+    mockTest.createInstance()
 
     then:
     true == true


### PR DESCRIPTION
As mentioned in the [documentation](http://spockframework.github.io/spock/docs/1.1-rc-1/all_in_one.html#_mocking_classes), Java 8 is only supported from CGLIB 3.2.0 onwards.
